### PR TITLE
Add script name argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ username:
 password:
   description: 'Password used for authentication to the target registry.'
   required: true
+
+script-name:
+  description: 'Name of the buildah script to execute to build the image.'
+  required: true
+  default: 'buildah.sh'
 ```
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
   password:
     description: 'Password used for authentication to the target registry.'
     required: true
+  script-name:
+    description: 'Name of the buildah script to execute to build the image.'
+    required: true
+    default: 'buildah.sh'
 
 outputs:
   image-path:
@@ -35,8 +39,8 @@ runs:
     - name: Build image
       shell: bash
       run: |
-        echo "Running buildah.sh script in directory ${{ inputs.image-tag }}"
-        ${{ inputs.image-tag }}/buildah.sh
+        echo "Running ${{ inputs.script-name }} script in directory ${{ inputs.image-tag }}"
+        ${{ inputs.image-tag }}/${{ inputs.script-name }}
     - name: Push image
       id: push
       shell: bash


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows specifying the file name of the buildah script to be executed.
Besides decreasing the amount of hardcoded values, this allows for executing two different scripts under the same directory (image tag) - e.g. config images corresponding to the main image.

