### PR TITLE
Use lowercase buildah imageID

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,8 @@ runs:
       run: |
         echo "::group::Push"
         IMG=${{ inputs.remote-registry }}/${{ inputs.image-name }}:${{ inputs.image-tag }}-${{ inputs.short-sha }}
-        buildah push --creds=${{ inputs.username }}:${{ inputs.password }} ${{ inputs.image-tag }} ${IMG}
+        IMG_WITHOUT_SHA=${{ inputs.remote-registry }}/${{ inputs.image-name }}:${{ inputs.image-tag }}
+        buildah push --creds=${{ inputs.username }}:${{ inputs.password }} ${IMG_WITHOUT_SHA} ${IMG}
         echo "::set-output name=image-path::${IMG}"
         echo "Pushed image to ${IMG}"
         echo "::endgroup::"

--- a/action.yml
+++ b/action.yml
@@ -49,8 +49,9 @@ runs:
       run: |
         echo "::group::Push"
         IMG=${{ inputs.remote-registry }}/${{ inputs.image-name }}:${{ inputs.image-tag }}-${{ inputs.short-sha }}
-        IMG_WITHOUT_SHA=${{ inputs.remote-registry }}/${{ inputs.image-name }}:${{ inputs.image-tag }}
-        buildah push --creds=${{ inputs.username }}:${{ inputs.password }} ${IMG_WITHOUT_SHA} ${IMG}
+        # buildah imageID does not support uppercase characters, so 'buildah push' was called with lowercase imageID.
+        BUILDAH_IMG_ID=$(echo "${{ inputs.image-tag }}" | tr '[:upper:]' '[:lower:]')
+        buildah push --creds=${{ inputs.username }}:${{ inputs.password }} ${BUILDAH_IMG_ID} ${IMG}
         echo "::set-output name=image-path::${IMG}"
         echo "Pushed image to ${IMG}"
         echo "::endgroup::"


### PR DESCRIPTION
**What this PR does / why we need it**:
Use lowercase buildah imageID, as uppercase is not supported:

```
$ buildah push --creds='...' 2019-CU18 docker.io/portworx/pds-some-ds:2019-CU18-ccf8125
error pushing image "2019-CU18" to "docker://docker.io/portworx/pds-some-ds:2019-CU18-ccf8125": repository name must be lowercase
ERRO[0000] exit status 125                              
```